### PR TITLE
Fix WiFi disconnect event not being propageted.

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -367,7 +367,7 @@ esp_err_t WiFiGenericClass::_eventCallback(void *arg, system_event_t *event)
             (reason >= WIFI_REASON_BEACON_TIMEOUT && reason != WIFI_REASON_AUTH_FAIL)) &&
             WiFi.getAutoReconnect())
         {
-            WiFi.disconnect(true);
+            WiFi.disconnect();
             WiFi.begin();
         }
     } else if(event->event_id == SYSTEM_EVENT_STA_GOT_IP) {


### PR DESCRIPTION
Relative to #3006. 
A short recap:  
I've just removed the `true` from the disconnect event callback in order to prevent the WiFi module to be stopped. This somehow prevented the disconnect event to be propagated.

